### PR TITLE
Add missing noisy gridsearch configs

### DIFF
--- a/resources/experiment_configs/gridsearch/noisy_labels/camelyon_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/camelyon_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_camelyon_vote_finegrained",
+        "datasetPath": "resources/datasets/camelyon",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/civilcomments_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/civilcomments_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_civilcomments_vote_finegrained",
+        "datasetPath": "resources/datasets/civilcomments",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/clipart_painting_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/clipart_painting_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_clipart_painting_vote_finegrained",
+        "datasetPath": "resources/datasets/clipart_painting",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/clipart_real_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/clipart_real_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_clipart_real_vote_finegrained",
+        "datasetPath": "resources/datasets/clipart_real",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/clipart_sketch_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/clipart_sketch_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_clipart_sketch_vote_finegrained",
+        "datasetPath": "resources/datasets/clipart_sketch",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/fmow_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/fmow_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_fmow_vote_finegrained",
+        "datasetPath": "resources/datasets/fmow",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/glue_mrpc_train_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/glue_mrpc_train_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_glue_mrpc_train_vote_finegrained",
+        "datasetPath": "resources/datasets/glue/mrpc_train",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/iwildcam_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/iwildcam_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_iwildcam_vote_finegrained",
+        "datasetPath": "resources/datasets/iwildcam",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/painting_clipart_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/painting_clipart_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_painting_clipart_vote_finegrained",
+        "datasetPath": "resources/datasets/painting_clipart",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/painting_real_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/painting_real_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_painting_real_vote_finegrained",
+        "datasetPath": "resources/datasets/painting_real",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/painting_sketch_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/painting_sketch_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_painting_sketch_vote_finegrained",
+        "datasetPath": "resources/datasets/painting_sketch",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/real_clipart_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/real_clipart_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_real_clipart_vote_finegrained",
+        "datasetPath": "resources/datasets/real_clipart",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/real_painting_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/real_painting_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_real_painting_vote_finegrained",
+        "datasetPath": "resources/datasets/real_painting",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/real_sketch_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/real_sketch_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_real_sketch_vote_finegrained",
+        "datasetPath": "resources/datasets/real_sketch",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/sketch_clipart_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/sketch_clipart_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_sketch_clipart_vote_finegrained",
+        "datasetPath": "resources/datasets/sketch_clipart",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/sketch_painting_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/sketch_painting_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_sketch_painting_vote_finegrained",
+        "datasetPath": "resources/datasets/sketch_painting",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}

--- a/resources/experiment_configs/gridsearch/noisy_labels/sketch_real_vote_finegrained.json
+++ b/resources/experiment_configs/gridsearch/noisy_labels/sketch_real_vote_finegrained.json
@@ -1,0 +1,29 @@
+{
+    "experiment": {
+        "name": "gridsearch_sketch_real_vote_finegrained",
+        "datasetPath": "resources/datasets/sketch_real",
+        "partitionMethod": "random",
+        "numSamples": 1000,
+        "budget": 1000,
+        "iterations": 1000,
+        "uniqueIndices": false,
+        "fitOracleSize": false,
+        "parallel": true
+    },
+    "epsilon_range": {
+        "min": 0.35,
+        "max": 0.49,
+        "step": 0.01
+    },
+    "recursive": false,
+    "epsilon_metric": "all",
+    "epsilon_metric_threshold": 0.9,
+    "noisy_oracle": "vote",
+    "methods": [
+        {
+            "name": "Model Picker",
+            "type": "model_picker",
+            "epsilon": 0.49
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- generate missing noisy gridsearch configs for all datasets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e101f924c832d8f06d31d7e694c5d